### PR TITLE
fix(deploy): grant write permissions to gh-pages action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 
 # 添加權限配置
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 


### PR DESCRIPTION
The `peaceiris/actions-gh-pages` action requires `contents: write` permission to push the built assets to the `gh-pages` branch. The workflow was previously configured with `contents: read`, which caused the action to fail with a permission denied error.

This change updates the `.github/workflows/deploy.yml` file to grant the necessary write permissions, allowing the action to successfully deploy to GitHub Pages.